### PR TITLE
attestationreport: use current TCB instead of reported TCB for checks

### DIFF
--- a/attestationreport/attestationreport.go
+++ b/attestationreport/attestationreport.go
@@ -1118,10 +1118,10 @@ func checkExtensionUint8(cert *x509.Certificate, oid string, value uint8) error 
 				return fmt.Errorf("extension %v value[0] = %v does not match expected value 2", oid, ext.Value[0])
 			}
 			if ext.Value[1] != 0x1 {
-				return fmt.Errorf("extension %v value[1] = %v does not match expected value 1", oid, ext.Value[0])
+				return fmt.Errorf("extension %v value[1] = %v does not match expected value 1", oid, ext.Value[1])
 			}
 			if ext.Value[2] != value {
-				return fmt.Errorf("extension %v value[2] = %v does not match expected value %v", oid, ext.Value[0], value)
+				return fmt.Errorf("extension %v value[2] = %v does not match expected value %v", oid, ext.Value[2], value)
 			}
 			return nil
 		}

--- a/attestationreport/snp.go
+++ b/attestationreport/snp.go
@@ -421,7 +421,7 @@ func verifySnpSignature(reportRaw []byte, report snpreport, certs CertChain) (Si
 func verifySnpExtensions(cert *x509.Certificate, report *snpreport) (ResultMulti, bool) {
 	result := ResultMulti{}
 	ok := true
-	tcb := report.ReportedTcb
+	tcb := report.CurrentTcb
 
 	if err := checkExtensionUint8(cert, "1.3.6.1.4.1.3704.1.3.1", uint8(tcb)); err != nil {
 		msg := fmt.Sprintf("SEV BL Extension Check failed: %v", err)


### PR DESCRIPTION
Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>