### PR TITLE
cmcd: Specify full address in config file instead of port

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ The *cmcd* and *provserver* require JSON configuration files. An example setup w
 required configuration files is provided in the ```examples/``` folder of this repository.
 
 The *cmcd* requires a JSON configuration file with the following information:
-- **port**: The port the *cmcd* should listen on
+- **addr**: The address the *cmcd* should listen on, e.g. 127.0.0.1:9955
 - **provServerAddr**: The URL of the provisioning server. The server issues certificates for the
 TPM or software keys. In case of the TPM, the TPM *Credential Activation* process is performed.
 - **localPath**: the local path to store the meta-data and internal files. In a local setup, all
@@ -182,7 +182,7 @@ RSA4096, EC256, EC384, EC521
 
 ```json
 {
-    "port": 9955,
+    "addr": "127.0.0.1:9955",
     "provServerAddr": "http://127.0.0.1:9001/",
     "serverPath": "drtm-example/",
     "localPath": "metadata/",

--- a/cmcd/helpers.go
+++ b/cmcd/helpers.go
@@ -71,7 +71,7 @@ func getFilePath(p, base string) string {
 
 func printConfig(c *config) {
 	log.Info("Using the following configuration:")
-	log.Info("\tCMC Port                 : ", c.Port)
+	log.Info("\tCMC Listen Address       : ", c.Addr)
 	log.Info("\tProvisioning Server URL  : ", c.ProvServerAddr)
 	log.Info("\tLocal Config Path        : ", c.LocalPath)
 	log.Info("\tFetch Metadata           : ", c.FetchMetadata)

--- a/cmcd/main.go
+++ b/cmcd/main.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strconv"
 
 	"encoding/json"
 	"flag"
@@ -38,7 +37,7 @@ import (
 )
 
 type config struct {
-	Port                  int      `json:"port"`
+	Addr                  string   `json:"addr"`
 	ProvServerAddr        string   `json:"provServerAddr"`
 	LocalPath             string   `json:"localPath"`
 	FetchMetadata         bool     `json:"fetchMetadata"`
@@ -271,8 +270,7 @@ func main() {
 
 	server := NewServer(serverConfig)
 
-	addr := "127.0.0.1:" + strconv.Itoa(c.Port)
-	err = Serve(addr, &server)
+	err = Serve(c.Addr, &server)
 	if err != nil {
 		log.Error(err)
 		return

--- a/example-setup/cmcd-conf.json
+++ b/example-setup/cmcd-conf.json
@@ -1,5 +1,5 @@
 {
-    "port": 9955,
+    "addr": "127.0.0.1:9955",
     "provServerAddr": "http://127.0.0.1:9001/",
     "localPath": "data-cmc/",
     "fetchMetadata": true,


### PR DESCRIPTION
Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>