### PR TITLE
policies: make policy engines optional

### DIFF
--- a/attestationreport/attestationreport_test.go
+++ b/attestationreport/attestationreport_test.go
@@ -185,7 +185,7 @@ func TestVerify(t *testing.T) {
 				return
 			}
 
-			got := Verify(string(ar), *tt.args.nonce, *tt.args.caCertPem, nil, tt.args.serializer)
+			got := Verify(string(ar), *tt.args.nonce, *tt.args.caCertPem, nil, 0, tt.args.serializer)
 			if got.Success != tt.want.Success {
 				t.Errorf("Result.Success = %v, want %v", got.Success, tt.want.Success)
 			}

--- a/attestationreport/jspolicies.go
+++ b/attestationreport/jspolicies.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2021 Fraunhofer AISEC
+// Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !nodefaults || jspolicies
+
+package attestationreport
+
+import (
+	"encoding/json"
+
+	"github.com/Fraunhofer-AISEC/cmc/jspolicies"
+)
+
+type JsPolicyEngine struct{}
+
+func init() {
+	policyEngines[PolicyEngineSelect_JS] = JsPolicyEngine{}
+}
+
+func (p JsPolicyEngine) Validate(policies []byte, result VerificationResult) bool {
+	vr, err := json.Marshal(result)
+	if err != nil {
+		log.Errorf("Failed to marshal verification result: %v", err)
+		return false
+	}
+	engine := jspolicies.NewJsPolicyEngine(policies)
+	return engine.Validate(vr)
+}

--- a/cmcd/coap.go
+++ b/cmcd/coap.go
@@ -33,7 +33,6 @@ import (
 	"github.com/plgd-dev/go-coap/v3/mux"
 
 	// local modules
-	ip "github.com/Fraunhofer-AISEC/cmc/attestationpolicies"
 	ar "github.com/Fraunhofer-AISEC/cmc/attestationreport"
 	api "github.com/Fraunhofer-AISEC/cmc/coapapi"
 )
@@ -168,18 +167,8 @@ func Verify(w mux.ResponseWriter, r *mux.Message) {
 		return
 	}
 
-	// The verifying party can optionally specify custom policies that should be verified
-	// If present, create a policy validator to be handed over to Verify()
-	var policies []ar.Policies
-	if req.Policies != nil {
-		log.Trace("Policies specified. Creating policy validator for remote attestation")
-		policies = append(policies, ip.NewPolicyValidator(req.Policies))
-	} else {
-		log.Trace("No policies specified. Performing default remote attestation")
-	}
-
 	log.Debug("Verifier: Verifying Attestation Report")
-	result := ar.Verify(string(req.AttestationReport), req.Nonce, req.Ca, policies, serverConfig.Serializer)
+	result := ar.Verify(string(req.AttestationReport), req.Nonce, req.Ca, req.Policies, ar.PolicyEngineSelect_JS, serverConfig.Serializer)
 
 	log.Debug("Verifier: Marshaling Attestation Result")
 	data, err := json.Marshal(result)

--- a/cmcd/grpc.go
+++ b/cmcd/grpc.go
@@ -33,7 +33,7 @@ import (
 	"google.golang.org/grpc"
 
 	// local modules
-	ip "github.com/Fraunhofer-AISEC/cmc/attestationpolicies"
+
 	ar "github.com/Fraunhofer-AISEC/cmc/attestationreport"
 	api "github.com/Fraunhofer-AISEC/cmc/grpcapi"
 )
@@ -123,18 +123,8 @@ func (s *GrpcServer) Verify(ctx context.Context, in *api.VerificationRequest) (*
 
 	log.Info("Received Connection Request Type 'Verification Request'")
 
-	// The verifying party can optionally specify custom policies that should be verified
-	// If present, create a policy validator to be handed over to Verify()
-	var policies []ar.Policies
-	if in.Policies != nil {
-		log.Trace("Policies specified. Creating policy validator for remote attestation")
-		policies = append(policies, ip.NewPolicyValidator(in.Policies))
-	} else {
-		log.Trace("No policies specified. Performing default remote attestation")
-	}
-
 	log.Info("Verifier: Verifying Attestation Report")
-	result := ar.Verify(string(in.AttestationReport), in.Nonce, in.Ca, policies, s.config.Serializer)
+	result := ar.Verify(string(in.AttestationReport), in.Nonce, in.Ca, in.Policies, ar.PolicyEngineSelect_JS, s.config.Serializer)
 
 	log.Info("Verifier: Marshaling Attestation Result")
 	data, err := json.Marshal(result)

--- a/example-setup/cmcd-conf.json
+++ b/example-setup/cmcd-conf.json
@@ -8,7 +8,6 @@
     "useIma": false,
     "imaPcr": 10,
     "keyConfig": "EC256",
-    "policies": "policies.json",
     "serialization": "json",
     "api": "grpc"
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.18
 
 require (
 	github.com/Fraunhofer-AISEC/go-attestation v0.3.3-0.20221021134609-a1d5c57b1083
-	github.com/fxamacker/cbor v1.5.1
 	github.com/fxamacker/cbor/v2 v2.4.0
 	github.com/google/go-tpm v0.3.3
 	github.com/mattn/go-sqlite3 v1.14.9

--- a/go.sum
+++ b/go.sum
@@ -156,11 +156,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
-github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/cockroachdb/datadriven v0.0.0-20200714090401-bf6692d28da5/go.mod h1:h6jFvWxBdQXxjopDMZyH2UVceIRfR84bdzbkoKrsWNo=
 github.com/cockroachdb/errors v1.2.4/go.mod h1:rQD95gz6FARkaKkQXUksEje/d9a6wBJoCr5oaCLELYA=
@@ -210,7 +206,6 @@ github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5y
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
-github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.0.14/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.3.0-java/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -229,8 +224,6 @@ github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3n
 github.com/fullstorydev/grpcurl v1.8.0/go.mod h1:Mn2jWbdMrQGJQ8UD62uNyMumT2acsZUCkZIqFxsQf1o=
 github.com/fullstorydev/grpcurl v1.8.1/go.mod h1:3BWhvHZwNO7iLXaQlojdg5NA6SxUDePli4ecpK1N7gw=
 github.com/fullstorydev/grpcurl v1.8.2/go.mod h1:YvWNT3xRp2KIRuvCphFodG0fKkMXwaxA9CJgKCcyzUQ=
-github.com/fxamacker/cbor v1.5.1 h1:XjQWBgdmQyqimslUh5r4tUGmoqzHmBFQOImkWGi2awg=
-github.com/fxamacker/cbor v1.5.1/go.mod h1:3aPGItF174ni7dDzd6JZ206H8cmr4GDNBGpPa971zsU=
 github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
@@ -927,8 +920,6 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220630215102-69896b714898/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20221004154528-8021a29435af h1:wv66FM3rLZGPdxpYL+ApnDe2HzHcTFta3z5nsc13wI4=
-golang.org/x/net v0.0.0-20221004154528-8021a29435af/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.4.0 h1:Q5QPcMlvfxFTAPV0+07Xz/MpK9NTXu2VDUuy0FeMfaU=
 golang.org/x/net v0.4.0/go.mod h1:MBQ8lrhLObU/6UmLb4fmbmk5OcyYmqtbGd/9yIeKjEE=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1044,8 +1035,6 @@ golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875 h1:AzgQNqF+FKwyQ5LbVrVqOcuuFB67N47F9+htZYH0wFM=
-golang.org/x/sys v0.0.0-20221006211917-84dc82d7e875/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
 golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -1058,7 +1047,6 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.5.0 h1:OLmvp0KP+FVG99Ct/qFiL/Fhk4zp4QQnZ7b2U+5piUM=
 golang.org/x/text v0.5.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
@@ -1256,8 +1244,6 @@ google.golang.org/genproto v0.0.0-20210728212813-7823e685a01f/go.mod h1:ob2IJxKr
 google.golang.org/genproto v0.0.0-20210805201207-89edb61ffb67/go.mod h1:ob2IJxKrgPT52GcgX759i1sleT07tiKowYBGbczaW48=
 google.golang.org/genproto v0.0.0-20210813162853-db860fec028c/go.mod h1:cFeNkxwySK631ADgubI+/XFU/xp8FD5KIVV4rj8UC5w=
 google.golang.org/genproto v0.0.0-20210821163610-241b8fcbd6c8/go.mod h1:eFjDcFEctNawg4eG61bRv87N7iHBWyVhJu7u1kqDUXY=
-google.golang.org/genproto v0.0.0-20211222154725-9823f7ba7562 h1:sZWkpp+mMCIr/XzilKM5CjCxqe2o7SyJ+kz097OkcNM=
-google.golang.org/genproto v0.0.0-20211222154725-9823f7ba7562/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37 h1:jmIfw8+gSvXcZSgaFAGyInDXeWzUhvYH57G/5GKMn70=
 google.golang.org/genproto v0.0.0-20221207170731-23e4bf6bdc37/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
@@ -1294,11 +1280,8 @@ google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
-google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.51.0 h1:E1eGv1FTqoLIdnBCZufiSHgKjlqG6fKFf6pPWtMTh8U=
 google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
-google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0 h1:M1YKkFIboKNieVO5DLUEVzQfGwJD30Nv2jfUgzb5UcE=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -1314,7 +1297,6 @@ google.golang.org/protobuf v1.25.1-0.20200805231151-a709e31e5d12/go.mod h1:9JNX7
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/jspolicies/jspolicies.go
+++ b/jspolicies/jspolicies.go
@@ -13,25 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package attestationpolicies
+package jspolicies
 
 import (
-	"encoding/json"
-
-	ar "github.com/Fraunhofer-AISEC/cmc/attestationreport"
 	"github.com/robertkrimen/otto"
 	"github.com/sirupsen/logrus"
 )
 
-var log = logrus.WithField("service", "policy-agent")
+var log = logrus.WithField("service", "jspolicies")
 
-// JavaScriptValidator is a javascript implementation of the
+// JsPolicyEngine is a javascript implementation of the
 // attestation report generic PolicyValidator interface
-type JavaScriptValidator struct {
+type JsPolicyEngine struct {
 	policies []byte
 }
 
-// NewPolicyValidator creates a new JavaScriptValidator with custom policies.
+// NewJsPolicyEngine creates a new JsPolicyEngine with custom policies.
 // Custom policies are handed over as a byte array. This implementation
 // accepts custom policies as javascript code. The javascript code
 // can parse the VerificationResult in the variable 'json', i.e.:
@@ -49,29 +46,23 @@ type JavaScriptValidator struct {
 //			success = false;
 //		}
 //	    success
-func NewPolicyValidator(policies []byte) *JavaScriptValidator {
-	return &JavaScriptValidator{
+func NewJsPolicyEngine(policies []byte) *JsPolicyEngine {
+	return &JsPolicyEngine{
 		policies: policies,
 	}
 }
 
 // Validate uses a javascript engine to validate the JavaScriptValidator's
 // custom javascript policies against the verification result
-func (p *JavaScriptValidator) Validate(result ar.VerificationResult) bool {
+func (p *JsPolicyEngine) Validate(result []byte) bool {
 
 	log.Debugf("Validating custom javascript policies")
-
-	vr, err := json.Marshal(result)
-	if err != nil {
-		log.Errorf("Failed to marshal verification result: %v", err)
-		return false
-	}
 
 	// Create new javascript engine
 	vm := otto.New()
 
 	// Set variable json = vr
-	vm.Set("json", string(vr))
+	vm.Set("json", string(result))
 
 	// Run javascript validation
 	val, err := vm.Run(string(p.policies))

--- a/jspolicies/jspolicies_test.go
+++ b/jspolicies/jspolicies_test.go
@@ -13,13 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package attestationpolicies
+package jspolicies
 
 import (
-	"encoding/json"
 	"testing"
 
-	ar "github.com/Fraunhofer-AISEC/cmc/attestationreport"
 	"github.com/sirupsen/logrus"
 )
 
@@ -57,18 +55,11 @@ func TestValidate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
-			// Marshal Verification Result
-			var vr ar.VerificationResult
-			err := json.Unmarshal(tt.args.result, &vr)
-			if err != nil {
-				t.Errorf("Test preparation: failed to marshal: %v", err)
-			}
-
 			// Prepare policy validator
-			v := NewPolicyValidator(tt.args.policies)
+			v := NewJsPolicyEngine(tt.args.policies)
 
 			// Test policy validaton
-			got := v.Validate(vr)
+			got := v.Validate(tt.args.result)
 			if got != tt.want {
 				t.Errorf("Result.Success = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Introduce tag jspolicies to make JavaScript
policy engine optional

Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>