### PR TITLE
attestedtls: perform unique channel binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ testtool -mode verify -ca $CMC_ROOT/cmc-data/pki/ca.pem [-policies $CMC_ROOT/cmc
 
 ```sh
 # Run an attested TLS server
-testtool -mode listen -addr 0.0.0.0:4443 -ca $CMC_ROOT/cmc-data/pki/ca.pem
+testtool -mode listen -addr 0.0.0.0:4443 -ca $CMC_ROOT/cmc-data/pki/ca.pem -mtls
 
 # Run an attested TLS client estblishing a mutually attested TLS connection to the server
 testtool -mode dial -addr localhost:4443 -ca $CMC_ROOT/cmc-data/pki/ca.pem -mtls

--- a/attestationreport/json.go
+++ b/attestationreport/json.go
@@ -195,7 +195,7 @@ func (s JsonSerializer) VerifyToken(data []byte, roots []*x509.Certificate) (Tok
 
 	jwsData, err := jose.ParseSigned(string(data))
 	if err != nil {
-		msg := fmt.Sprintf("Data could not be parsed - %v", err)
+		msg := fmt.Sprintf("Data could not be parsed: %v", err)
 		result.Summary.setFalseMulti(&msg)
 		return result, nil, false
 	}

--- a/attestedtls/config.go
+++ b/attestedtls/config.go
@@ -37,13 +37,13 @@ type cmcConfig struct {
 	cmcApi   CmcApi
 	ca       []byte
 	policies []byte
+	mtls     bool
 }
 
 type CmcApi interface {
-	createARRequest(nonce []byte) ([]byte, error)
 	parseARResponse(data []byte) ([]byte, error)
-	obtainAR(request []byte, cc cmcConfig, cert []byte) ([]byte, error)
-	verifyAR(nonce, report []byte, cc cmcConfig) error
+	obtainAR(cc cmcConfig, chbindings []byte) ([]byte, error)
+	verifyAR(chbindings, report []byte, cc cmcConfig) error
 	fetchSignature(cc cmcConfig, digest []byte, opts crypto.SignerOpts) ([]byte, error)
 	fetchCerts(cc cmcConfig) ([][]byte, error)
 }
@@ -81,5 +81,13 @@ func WithCmcCa(pem []byte) ConnectionOption[cmcConfig] {
 func WithCmcPolicies(policies []byte) ConnectionOption[cmcConfig] {
 	return func(c *cmcConfig) {
 		c.policies = policies
+	}
+}
+
+// WithMtls specifies whether to perform mutual TLS with mutual attestation
+// or server-side authentication and attestation only
+func WithMtls(mtls bool) ConnectionOption[cmcConfig] {
+	return func(c *cmcConfig) {
+		c.mtls = mtls
 	}
 }

--- a/attestedtls/key.go
+++ b/attestedtls/key.go
@@ -95,8 +95,6 @@ func GetCert(moreConfigs ...ConnectionOption[cmcConfig]) (tls.Certificate, error
 		return tls.Certificate{}, fmt.Errorf("could not parse certificate: %w", err)
 	}
 
-	log.Tracef("Retrieved TLS certificate %v with SANS %v", x509Cert.Subject.CommonName, x509Cert.DNSNames)
-
 	// Create TLS Cert
 	tlsCert.Leaf = x509Cert
 	tlsCert.PrivateKey = PrivateKey{

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -84,16 +84,12 @@ func LoadCerts(data []byte) ([]*x509.Certificate, error) {
 
 func PrintTlsConfig(conf *tls.Config, roots []byte) error {
 	for i, certs := range conf.Certificates {
-		log.Tracef("TLS leaf certificate %v: %v, SubjectKeyID %v, AuthorityKeyID %v",
-			i, certs.Leaf.Subject.CommonName,
-			hex.EncodeToString(certs.Leaf.SubjectKeyId),
-			hex.EncodeToString(certs.Leaf.AuthorityKeyId))
 		for j, data := range certs.Certificate {
 			c, err := LoadCert(data)
 			if err != nil {
 				return fmt.Errorf("failed to convert certificate: %w", err)
 			}
-			log.Tracef("Cert %v TLS Certificate Chain %v: %v, SubjectKeyID %v, AuthorityKeyID %v",
+			log.Tracef("Cert %v:%v: %v, SubjectKeyID %v, AuthorityKeyID %v",
 				i, j, c.Subject.CommonName,
 				hex.EncodeToString(c.SubjectKeyId),
 				hex.EncodeToString(c.AuthorityKeyId))
@@ -104,7 +100,7 @@ func PrintTlsConfig(conf *tls.Config, roots []byte) error {
 		return fmt.Errorf("failed to load certs: %w", err)
 	}
 	for i, c := range certs {
-		log.Tracef("Trusted Root Cert %v: %v, SubjectKeyID %v",
+		log.Tracef("CA Cert%v: %v, SubjectKeyID %v",
 			i, c.Subject.CommonName, hex.EncodeToString(c.SubjectKeyId))
 	}
 	return nil


### PR DESCRIPTION
Perform unique channel binding with the TLS exporter mechanism to bind attestation to secure channel instance instead of end-point only.

Signed-off-by: Simon Ott <simon.ott@aisec.fraunhofer.de>