### PR TITLE
Support VCEK certs where certain certificate extensions pad one byte value with 0x00

### DIFF
--- a/tpmdriver/akcsr.go
+++ b/tpmdriver/akcsr.go
@@ -88,13 +88,6 @@ type publicKeyInfo struct {
 	PublicKey asn1.BitString
 }
 
-var publicKeyAlgoName = [...]string{
-	x509.RSA:     "RSA",
-	x509.DSA:     "DSA",
-	x509.ECDSA:   "ECDSA",
-	x509.Ed25519: "Ed25519",
-}
-
 // OIDs for signature algorithms
 //
 //	pkcs-1 OBJECT IDENTIFIER ::= {


### PR DESCRIPTION
Addresses issue #82 where certain generated AMD certificates pad the 8 bit values stored in the certificate extensions with `0x00` in case the most significant bit is `1`. 

An additional commit removes an unused variable. 