### PR TITLE
attestedtls: Avoid additional RTT

### DIFF
--- a/attestationreport/cbor.go
+++ b/attestationreport/cbor.go
@@ -132,7 +132,6 @@ func (s CborSerializer) VerifyToken(data []byte, roots []*x509.Certificate) (Tok
 		log.Warnf("failed to verify COSE: no signatures present")
 		return result, nil, false
 	}
-	log.Tracef("Number of COSE signatures: %v", len(msgToVerify.Signatures))
 	verifiers := make([]cose.Verifier, 0)
 	for i, sig := range msgToVerify.Signatures {
 		result.SignatureCheck = append(result.SignatureCheck, SignatureResult{})

--- a/attestedtls/attestation.go
+++ b/attestedtls/attestation.go
@@ -17,7 +17,6 @@ package attestedtls
 
 import (
 	"crypto/tls"
-	"errors"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
@@ -34,7 +33,7 @@ func attestDialer(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 		// Obtain attestation report from local cmcd
 		resp, err := cc.cmcApi.obtainAR(cc, chbindings)
 		if err != nil {
-			return fmt.Errorf("could not obtain response: %w", err)
+			return fmt.Errorf("could not obtain dialer AR: %w", err)
 		}
 
 		// Send created attestation report to listener
@@ -52,13 +51,11 @@ func attestDialer(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 	log.Trace("Waiting for attestation report from listener")
 	data, err := Read(conn)
 	if err != nil {
-		_ = sendAck(false, conn)
 		return fmt.Errorf("failed to read response: %w", err)
 	}
 
 	report, err := cc.cmcApi.parseARResponse(data)
 	if err != nil {
-		_ = sendAck(false, conn)
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
@@ -66,16 +63,10 @@ func attestDialer(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 	log.Trace("Verifying attestation report from listener")
 	err = cc.cmcApi.verifyAR(chbindings, report, cc)
 	if err != nil {
-		_ = sendAck(false, conn)
 		return err
 	}
 
-	// Send final ACK to indicate connection establishment
-	err = sendAck(true, conn)
-	if err != nil {
-		return fmt.Errorf("failed to send ACK: %w", err)
-	}
-	log.Trace("Verified listener")
+	log.Trace("Attestation successful")
 
 	return nil
 }
@@ -86,33 +77,7 @@ func attestListener(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 	log.Trace("Generating listener attestation report")
 	resp, err := cc.cmcApi.obtainAR(cc, chbindings)
 	if err != nil {
-		return fmt.Errorf("could not obtain response: %w", err)
-	}
-
-	// Wait for attestation report from dialer if mTLS is to be performed
-	if cc.mtls {
-		log.Debug("Performing mutual attestation: Waiting for dialer attestation report")
-		data, err := Read(conn)
-		if err != nil {
-			_ = sendAck(false, conn)
-			return fmt.Errorf("failed to read response: %w", err)
-		}
-
-		report, err := cc.cmcApi.parseARResponse(data)
-		if err != nil {
-			_ = sendAck(false, conn)
-			return fmt.Errorf("failed to parse response: %w", err)
-		}
-
-		// Verify AR from dialer with own channel bindings
-		log.Trace("Verifying attestation report from dialer...")
-		err = cc.cmcApi.verifyAR(chbindings, report, cc)
-		if err != nil {
-			_ = sendAck(false, conn)
-			return err
-		}
-	} else {
-		log.Debug("No mTLS performed")
+		return fmt.Errorf("could not obtain listener AR: %w", err)
 	}
 
 	// Send own attestation report to dialer
@@ -122,45 +87,30 @@ func attestListener(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 		return fmt.Errorf("failed to send AR: %w", err)
 	}
 
-	// Receive Ack to know if verification was successful
-	log.Trace("Waiting for dialer to complete remote attestation")
-	err = receiveAck(conn)
-	if err != nil {
-		return fmt.Errorf("other side failed to verify AR: %w", err)
-	}
-	log.Debug("Attestation to peer successful")
+	// Wait for attestation report from dialer if mTLS is to be performed
+	if cc.mtls {
+		log.Debug("Performing mutual attestation: Waiting for dialer attestation report")
+		data, err := Read(conn)
+		if err != nil {
+			return fmt.Errorf("failed to read response: %w", err)
+		}
 
-	return nil
-}
+		report, err := cc.cmcApi.parseARResponse(data)
+		if err != nil {
+			return fmt.Errorf("failed to parse response: %w", err)
+		}
 
-// Sends success ACK or failure to peer
-func sendAck(success bool, conn *tls.Conn) error {
-	log.Trace("Sending ACK...")
-
-	data := make([]byte, 1)
-	if success {
-		data[0] = 0
+		// Verify AR from dialer with own channel bindings
+		log.Trace("Verifying attestation report from dialer...")
+		err = cc.cmcApi.verifyAR(chbindings, report, cc)
+		if err != nil {
+			return err
+		}
 	} else {
-		data[0] = 1
+		log.Debug("No mTLS performed")
 	}
-	err := Write(data, conn)
-	if err != nil {
-		return fmt.Errorf("failed to write ACK: %w", err)
-	}
-	return nil
-}
 
-// Waits for and reads success ACK or failure
-// In case of failure, an error is returned
-func receiveAck(conn *tls.Conn) error {
-	log.Trace("Waiting for ACK...")
+	log.Trace("Attestation successful")
 
-	data, err := Read(conn)
-	if err != nil {
-		return fmt.Errorf("failed to read ACK: %w", err)
-	}
-	if len(data) != 1 || data[0] != 0 {
-		return errors.New("did not receive success ACK")
-	}
 	return nil
 }

--- a/attestedtls/coap.go
+++ b/attestedtls/coap.go
@@ -66,7 +66,7 @@ func (a CoapApi) obtainAR(cc cmcConfig, chbindings []byte) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error dialing: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	req := &api.AttestationRequest{

--- a/cmcd/coap.go
+++ b/cmcd/coap.go
@@ -135,8 +135,6 @@ func Attest(w mux.ResponseWriter, r *mux.Message) {
 		return
 	}
 
-	log.Debug("Prover: Finished")
-
 	// Serialize CoAP payload
 	resp := api.AttestationResponse{
 		AttestationReport: data,

--- a/cmcd/grpc.go
+++ b/cmcd/grpc.go
@@ -84,7 +84,6 @@ func (s *GrpcServer) Attest(ctx context.Context, in *api.AttestationRequest) (*a
 	report, err := ar.Generate(in.Nonce, s.config.Metadata, s.config.MeasurementInterfaces, s.config.Serializer)
 	if err != nil {
 		log.Errorf("Failed to generate attestation report: %v", err)
-		log.Info("Prover: Finished")
 		return &api.AttestationResponse{
 			Status: api.Status_FAIL,
 		}, nil
@@ -92,7 +91,6 @@ func (s *GrpcServer) Attest(ctx context.Context, in *api.AttestationRequest) (*a
 
 	if s.config.Signer == nil {
 		log.Error("No valid signer specified in config. Cannot sign attestation report")
-		log.Info("Prover: Finished")
 		return &api.AttestationResponse{
 			Status: api.Status_FAIL,
 		}, nil
@@ -108,12 +106,12 @@ func (s *GrpcServer) Attest(ctx context.Context, in *api.AttestationRequest) (*a
 		status = api.Status_OK
 	}
 
-	log.Info("Prover: Finished")
-
 	response := &api.AttestationResponse{
 		Status:            status,
 		AttestationReport: data,
 	}
+
+	log.Info("Prover: Finished")
 
 	return response, nil
 }


### PR DESCRIPTION
Only send AR, do not send ACK to avoid additional RTT.