### PR TITLE
added support for TPM_PCR_INIT_VALUE event to cmc/tpmdriver + some fixes

### DIFF
--- a/attestationreport/attestationreport.go
+++ b/attestationreport/attestationreport.go
@@ -112,7 +112,8 @@ type HashChainElem struct {
 	Pcr       int32       `json:"pcr" cbor:"1,keyasint"`
 	Sha256    []HexByte   `json:"sha256" cbor:"2,keyasint"`
 	Summary   bool        `json:"summary" cbor:"3,keyasint"` // Indicates if element represents final PCR value or single artifact
-	EventData []EventData `json:"eventdata,omitempty" cbor:"4,keyasint,omitempty"`
+	EventName []string    `json:"eventname,omitempty" cbor:"4,keyasint,omitempty"`
+	EventData []EventData `json:"eventdata,omitempty" cbor:"5,keyasint,omitempty"`
 }
 
 // TpmMeasurement represents the attestation report

--- a/cmcd/config.go
+++ b/cmcd/config.go
@@ -63,7 +63,7 @@ const (
 	logFlag            = "log"
 	storageFlag        = "storage"
 	cacheFlag          = "cache"
-	measurementLogFlag = "measuementLog"
+	measurementLogFlag = "measurementLog"
 )
 
 func getConfig() (*cmc.Config, error) {

--- a/example-setup/cmcd-conf.json
+++ b/example-setup/cmcd-conf.json
@@ -6,6 +6,7 @@
     "provServerAddr": "https://localhost:9000/",
     "drivers": [ "TPM" ],
     "useIma": false,
+    "measuementLog": false,
     "imaPcr": 10,
     "keyConfig": "EC256",
     "api": "grpc",

--- a/example-setup/testtool-config.json
+++ b/example-setup/testtool-config.json
@@ -10,6 +10,7 @@
     "ca": "../../cmc-data/pki/ca.pem",
     "policies": "",
     "mtls": true,
+    "measuementLog": false,
     "api": "grpc",
     "logLevel": "trace",
     "interval": "5m30s"

--- a/example-setup/testtool-lib-config.json
+++ b/example-setup/testtool-lib-config.json
@@ -10,6 +10,7 @@
     "policies": "",
     "mtls": true,
     "api": "libapi",
+    "measuementLog": false,
     "logLevel": "trace",
     "cache": "../../cmc-data/testtool-cache",
     "storage": "../../cmc-data/testtool-storage",

--- a/tpmdriver/tpmdriver.go
+++ b/tpmdriver/tpmdriver.go
@@ -214,14 +214,18 @@ func (t *Tpm) Measure(nonce []byte) (ar.Measurement, error) {
 	hashChain := make([]*ar.HashChainElem, len(t.Pcrs))
 	for i, num := range t.Pcrs {
 		sha256 := make([]ar.HexByte, 0)
-		eventDataArray := make([]ar.EventData, 0) //to capture additional EventData
+		eventNameArray := make([]string, 0)
+		eventDataArray := make([]ar.EventData, 0)
 
 		if t.MeasurementLog {
 			for _, digest := range biosMeasurements {
 				if num == *digest.Pcr {
 					sha256 = append(sha256, digest.Sha256)
+					eventNameArray = append(eventNameArray, digest.Name)
 
-					if t.MeasurementLog {
+					if digest.Name == "TPM_PCR_INIT_VALUE" {
+						eventDataArray = append(eventDataArray, ar.EventData{})
+					} else {
 						eventDataArray = append(eventDataArray, *digest.EventData)
 					}
 				}
@@ -239,6 +243,7 @@ func (t *Tpm) Measure(nonce []byte) (ar.Measurement, error) {
 		//appending EventData
 		if t.MeasurementLog {
 			hashChain[i].EventData = eventDataArray
+			hashChain[i].EventName = eventNameArray
 		}
 	}
 


### PR DESCRIPTION
The TPM_PCR_INIT_VALUE is an event in the eventlog that contains the initialization value for each PCR.