### PR TITLE
attestedtls: change prepended byte to data structure

### DIFF
--- a/attestedtls/attestation.go
+++ b/attestedtls/attestation.go
@@ -26,7 +26,17 @@ var id = "0000"
 
 var log = logrus.WithField("service", "atls")
 
+// wrapper structure for the attestation response
+type atlsPacket struct {
+	SelectionByte byte   `json:"selectionbyte" cbor:"0,keyasint"`
+	Response      []byte `json:"response,omitempty" cbor:"1,keyasint,omitempty"`
+}
+
 func attestDialer(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
+	//building the atls Message
+	response := atlsPacket{
+		SelectionByte: byte(cc.attest),
+	}
 
 	//optional: attest Client
 	if cc.attest == Attest_Mutual || cc.attest == Attest_Client {
@@ -37,24 +47,40 @@ func attestDialer(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 			return fmt.Errorf("could not obtain dialer AR: %w", err)
 		}
 
+		//adding the attestation report
+		response.Response = resp
+		//marshalling the packet
+		marshalledResponse, err := cc.cmc.Serializer.Marshal(response)
+		if err != nil {
+			log.Error("could not marshall atlsPacket")
+			return err
+		}
 		// Send created attestation report to listener
 		log.Tracef("Sending attestation report length %v to listener", len(resp))
 
-		err = Write(append([]byte{byte(cc.attest)}, resp...), conn)
+		err = Write(marshalledResponse, conn)
+
 		if err != nil {
 			return fmt.Errorf("failed to send AR: %w", err)
 		}
 		log.Trace("Sent AR")
 	} else {
+		//marshalling the packet
+		marshalledResponse, err := cc.cmc.Serializer.Marshal(response)
+		if err != nil {
+			log.Error("could not marshall atlsPacket")
+			return err
+		}
+
 		//if not sending attestation report, send the attestation mode
-		err := Write([]byte{byte(cc.attest)}, conn)
+		err = Write(marshalledResponse, conn)
 		if err != nil {
 			return fmt.Errorf("failed to send skip client Attestation: %w", err)
 		}
 		log.Debug("Skipping client-side attestation")
 	}
 
-	readvalue, err := readValue(conn, cc.attest, true)
+	readvalue, err := readValue(conn, cc.attest, true, cc)
 	if err != nil {
 		return err
 	}
@@ -78,6 +104,11 @@ func attestDialer(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 }
 
 func attestListener(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
+	//building the atls Message
+	response := atlsPacket{
+		SelectionByte: byte(cc.attest),
+	}
+
 	// optional: attest server
 	if cc.attest == Attest_Mutual || cc.attest == Attest_Server {
 		// Obtain own attestation report from local cmcd
@@ -87,22 +118,36 @@ func attestListener(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 			return fmt.Errorf("could not obtain AR of Listener : %w", err)
 		}
 
+		//adding the attestation report
+		response.Response = resp
+		//marshalling the packet
+		marshalledResponse, err := cc.cmc.Serializer.Marshal(response)
+		if err != nil {
+			log.Error("could not marshall atlsPacket")
+			return err
+		}
 		// Send own attestation report to dialer
 		log.Trace("Sending own attestation report")
-		err = Write(append([]byte{byte(cc.attest)}, resp...), conn)
+		err = Write(marshalledResponse, conn)
 		if err != nil {
 			return fmt.Errorf("failed to send AR: %w", err)
 		}
 	} else {
+		//marshalling the packet
+		marshalledResponse, err := cc.cmc.Serializer.Marshal(response)
+		if err != nil {
+			log.Error("could not marshall atlsPacket")
+			return err
+		}
 		//if not sending attestation report, send the attestation mode
-		err := Write([]byte{byte(cc.attest)}, conn)
+		err = Write(marshalledResponse, conn)
 		if err != nil {
 			return fmt.Errorf("failed to send skip client Attestation: %w", err)
 		}
 		log.Debug("Skipping server-side attestation")
 	}
 
-	readValue, err := readValue(conn, cc.attest, false)
+	readValue, err := readValue(conn, cc.attest, false, cc)
 	if err != nil {
 		return err
 	}
@@ -125,22 +170,27 @@ func attestListener(conn *tls.Conn, chbindings []byte, cc cmcConfig) error {
 	return nil
 }
 
-func readValue(conn *tls.Conn, selection AttestSelect, dialer bool) ([]byte, error) {
+func readValue(conn *tls.Conn, selection AttestSelect, dialer bool, cc cmcConfig) ([]byte, error) {
 	readvalue, err := Read(conn)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	packet := new(atlsPacket)
+	err = cc.cmc.Serializer.Unmarshal(readvalue, packet)
+	if err != nil {
+		log.Errorf("could not unmarshal atls response: %v", err)
+		return nil, err
 	}
 
 	selectionStr, errS1 := selectionString(byte(selection))
 	if errS1 != nil {
 		return nil, errS1
 	}
-
-	// the first byte should always be the attestation mode
-	if readvalue[0] == byte(selection) {
+	if packet.SelectionByte == byte(selection) {
 		log.Debugf("Matching attestation mode: [%v]", selectionStr)
 	} else {
-		reportByte := readvalue[0]
+		reportByte := packet.SelectionByte
 		reportStr, errS1 := selectionString(reportByte)
 		if errS1 != nil {
 			return nil, errS1
@@ -148,7 +198,7 @@ func readValue(conn *tls.Conn, selection AttestSelect, dialer bool) ([]byte, err
 		return nil, fmt.Errorf("mismatching attestation mode, local set to: [%v], while remote is set to: [%v]", selectionStr, reportStr)
 	}
 
-	return readvalue[1:], nil
+	return packet.Response, nil
 }
 
 func selectionString(selection byte) (string, error) {

--- a/attestedtls/dialer.go
+++ b/attestedtls/dialer.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"net"
 	"time"
+
+	ar "github.com/Fraunhofer-AISEC/cmc/attestationreport"
+	"github.com/Fraunhofer-AISEC/cmc/cmc"
 )
 
 // Wraps tls.Dial
@@ -60,6 +63,14 @@ func Dial(network string, addr string, config *tls.Config, moreConfigs ...Connec
 	// Check that selected API is implemented
 	if cc.cmcApi == nil {
 		return nil, fmt.Errorf("selected CMC API is not implemented")
+	}
+
+	if(cc.cmc == nil){
+		cc.cmc = &cmc.Cmc{}
+	}	
+	if(cc.cmc.Serializer == nil){
+		log.Trace("No Serializer defined: use as JsonSerializer as default")
+		cc.cmc.Serializer = ar.JsonSerializer{}
 	}
 
 	// Perform remote attestation with unique channel binding as specified in RFC5056,

--- a/attestedtls/listener.go
+++ b/attestedtls/listener.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"net"
 	"time"
+
+	ar "github.com/Fraunhofer-AISEC/cmc/attestationreport"
+	"github.com/Fraunhofer-AISEC/cmc/cmc"
 )
 
 const timeout = 10 * time.Second
@@ -118,6 +121,15 @@ func Listen(network, laddr string, config *tls.Config, moreConfigs ...Connection
 	// Check that selected API is implemented
 	if listener.cmcConfig.cmcApi == nil {
 		return listener, fmt.Errorf("selected CMC API is not implemented")
+	}
+
+
+	if(listener.cmc == nil){
+		listener.cmc = &cmc.Cmc{}
+	}	
+	if(listener.cmc.Serializer == nil){
+		log.Trace("No Serializer defined: use as JsonSerializer as default")
+		listener.cmc.Serializer = ar.JsonSerializer{}
 	}
 
 	// Listen

--- a/testtool/internal.go
+++ b/testtool/internal.go
@@ -54,6 +54,10 @@ func dialInternalAddr(c *config, api atls.CmcApiSelect, addr string, tlsConf *tl
 		atls.WithCmcNetwork(c.Network),
 		atls.WithResult(verificationResult),
 		atls.WithCmc(cmc))
+
+	if (err != nil){
+		return err
+	}
 	// Publish the attestation result asynchronously if publishing address was specified and
 	// and attestation was performed
 	if c.Publish != "" && (c.Attest == "mutual" || c.Attest == "server") {


### PR DESCRIPTION
draft commit for an extensible datastructure instead of a prepended byte.