### PR TITLE
attestedtls: send attestation report asynchronously

### DIFF
--- a/attestationreport/validationreport.go
+++ b/attestationreport/validationreport.go
@@ -707,7 +707,7 @@ func (r *VerificationResult) PrintErr() {
 				if !a.Success {
 					details := ""
 					if a.Pcr != nil {
-						details = "PCR%v"
+						details = fmt.Sprintf("PCR%v", *a.Pcr)
 					}
 					log.Warnf("%v Measurement %v: %v verification failed", details, a.Name, a.Digest)
 				}


### PR DESCRIPTION
If the attestation report is too large, both the
TLS dialer and listener block, as the attestation reports are exchanged at the same time. Send them asynchronously to avoid this.