### PR TITLE
attestedtls: new protocol

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -255,7 +255,7 @@ func Receive(conn net.Conn) ([]byte, uint32, error) {
 			payloadLen, MaxMsgLen)
 	}
 
-	log.Tracef("Decoded header. Type %v, length %v", TypeToString(msgType), payloadLen)
+	log.Tracef("Received header type %v. Receiving payload length %v", TypeToString(msgType), payloadLen)
 
 	// Read payload
 	payload := bytes.NewBuffer(nil)
@@ -268,8 +268,6 @@ func Receive(conn net.Conn) ([]byte, uint32, error) {
 		}
 		received += n
 		payload.Write(chunk[:n])
-
-		log.Tracef("Received chunk of %v bytes\n", n)
 
 		if received == payloadLen {
 			break

--- a/attestedhttp/client.go
+++ b/attestedhttp/client.go
@@ -57,7 +57,7 @@ type Transport struct {
 	// as we enforce aTLS as the underlying transport protocol
 
 	// Additional aTLS parameters
-	Attest      string
+	Attest      atls.AttestSelect
 	MutualTls   bool
 	CmcAddr     string
 	CmcApi      atls.CmcApiSelect
@@ -154,7 +154,7 @@ func prepareClient(c *Client) error {
 	if c.client == nil {
 
 		// Store aTLS and CMC configuration
-		cmcConfig.Attest = atls.GetAttestMode(c.Transport.Attest)
+		cmcConfig.Attest = c.Transport.Attest
 		cmcConfig.Ca = c.Transport.Ca
 		cmcConfig.Cmc = c.Transport.Cmc
 		cmcConfig.CmcAddr = c.Transport.CmcAddr

--- a/attestedhttp/server.go
+++ b/attestedhttp/server.go
@@ -30,7 +30,7 @@ type Server struct {
 	*http.Server
 
 	// Additional aTLS parameters
-	Attest      string
+	Attest      atls.AttestSelect
 	MutualTls   bool
 	CmcAddr     string
 	CmcApi      atls.CmcApiSelect

--- a/attestedtls/coap.go
+++ b/attestedtls/coap.go
@@ -44,7 +44,7 @@ func init() {
 }
 
 // Obtains attestation report from cmcd
-func (a CoapApi) obtainAR(cc CmcConfig, chbindings []byte) ([]byte, error) {
+func (a CoapApi) obtainAR(cc CmcConfig, chbindings []byte, params *AtlsHandshakeRequest) ([]byte, error) {
 
 	path := "/Attest"
 

--- a/attestedtls/dialer.go
+++ b/attestedtls/dialer.go
@@ -72,9 +72,10 @@ func Dial(network string, addr string, config *tls.Config, moreConfigs ...Connec
 
 	// Perform remote attestation with unique channel binding as specified in RFC5056,
 	// RFC5705, and RFC9266
-	err = attestDialer(conn, chbindings, cc)
+	err = atlsHandshakeStart(conn, chbindings, cc, Endpoint_Client)
+	err = aTlsHandshakeComplete(conn, err)
 	if err != nil {
-		return nil, fmt.Errorf("remote attestation failed: %w", err)
+		return nil, fmt.Errorf("atls handshake failed: %w", err)
 	}
 
 	log.Info("Client-side aTLS connection complete")

--- a/attestedtls/grpc.go
+++ b/attestedtls/grpc.go
@@ -54,7 +54,7 @@ func getCMCServiceConn(cc CmcConfig) (api.CMCServiceClient, *grpc.ClientConn, co
 }
 
 // Obtains attestation report from CMCd
-func (a GrpcApi) obtainAR(cc CmcConfig, chbindings []byte) ([]byte, error) {
+func (a GrpcApi) obtainAR(cc CmcConfig, chbindings []byte, params *AtlsHandshakeRequest) ([]byte, error) {
 
 	// Get backend connection
 	log.Tracef("Obtaining AR from local cmcd on %v", cc.CmcAddr)

--- a/attestedtls/libapi.go
+++ b/attestedtls/libapi.go
@@ -37,7 +37,7 @@ func init() {
 }
 
 // Obtains attestation report from CMCd
-func (a LibApi) obtainAR(cc CmcConfig, chbindings []byte) ([]byte, error) {
+func (a LibApi) obtainAR(cc CmcConfig, chbindings []byte, params *AtlsHandshakeRequest) ([]byte, error) {
 
 	if cc.Cmc == nil {
 		return nil, errors.New("internal error: cmc is nil")

--- a/attestedtls/listener.go
+++ b/attestedtls/listener.go
@@ -77,9 +77,10 @@ func (ln Listener) Accept() (net.Conn, error) {
 
 	// Perform remote attestation with unique channel binding as specified in RFC5056,
 	// RFC5705, and RFC9266
-	err = attestListener(tlsConn, chbindings, ln.CmcConfig)
+	err = atlsHandshakeStart(tlsConn, chbindings, ln.CmcConfig, Endpoint_Server)
+	err = aTlsHandshakeComplete(tlsConn, err)
 	if err != nil {
-		return nil, fmt.Errorf("remote attestation failed: %w", err)
+		return nil, fmt.Errorf("atls handshake failed: %w", err)
 	}
 
 	log.Info("Server-side aTLS connection complete")

--- a/attestedtls/socket.go
+++ b/attestedtls/socket.go
@@ -40,7 +40,7 @@ func init() {
 }
 
 // Obtains attestation report from cmcd
-func (a SocketApi) obtainAR(cc CmcConfig, chbindings []byte) ([]byte, error) {
+func (a SocketApi) obtainAR(cc CmcConfig, chbindings []byte, params *AtlsHandshakeRequest) ([]byte, error) {
 
 	// Establish connection
 	log.Tracef("Sending attestation request to cmcd via %v on %v", cc.Network, cc.CmcAddr)

--- a/cmcd/socket.go
+++ b/cmcd/socket.go
@@ -79,6 +79,8 @@ func (s SocketServer) Serve(addr string, cmc *cmc.Cmc) error {
 func handleIncoming(conn net.Conn, cmc *cmc.Cmc) {
 	defer conn.Close()
 
+	log.Infof("Received request from %v", conn.RemoteAddr().String())
+
 	payload, reqType, err := api.Receive(conn)
 	if err != nil {
 		s, err := detectSerialization(payload)
@@ -164,7 +166,7 @@ func attest(conn net.Conn, payload []byte, cmc *cmc.Cmc, s ar.Serializer) {
 
 func validate(conn net.Conn, payload []byte, cmc *cmc.Cmc, s ar.Serializer) {
 
-	log.Debug("Received Connection Request Type 'Verification Request'")
+	log.Debug("Received verification request")
 
 	req := new(api.VerificationRequest)
 	err := s.Unmarshal(payload, req)

--- a/testtool/http.go
+++ b/testtool/http.go
@@ -95,7 +95,7 @@ func requestInternal(c *config, api atls.CmcApiSelect, cmc *cmc.Cmc) error {
 		IdleConnTimeout: 60 * time.Second,
 		TLSClientConfig: tlsConfig,
 
-		Attest:      c.Attest,
+		Attest:      c.attest,
 		MutualTls:   c.Mtls,
 		CmcAddr:     c.CmcAddr,
 		CmcApi:      api,
@@ -106,7 +106,7 @@ func requestInternal(c *config, api atls.CmcApiSelect, cmc *cmc.Cmc) error {
 		ResultCb: func(result *ar.VerificationResult) {
 			// Publish the attestation result asynchronously if publishing address was specified and
 			// and attestation was performed
-			if c.Publish != "" && (c.Attest == "mutual" || c.Attest == "server") {
+			if c.Publish != "" && (c.attest == atls.Attest_Mutual || c.attest == atls.Attest_Server) {
 				wg := new(sync.WaitGroup)
 				wg.Add(1)
 				defer wg.Wait()
@@ -218,7 +218,7 @@ func serveInternal(c *config, api atls.CmcApiSelect, cmc *cmc.Cmc) {
 			Addr:      addr,
 			TLSConfig: tlsConfig,
 		},
-		Attest:      c.Attest,
+		Attest:      c.attest,
 		MutualTls:   c.Mtls,
 		CmcAddr:     c.CmcAddr,
 		CmcApi:      api,
@@ -227,7 +227,7 @@ func serveInternal(c *config, api atls.CmcApiSelect, cmc *cmc.Cmc) {
 		Ca:          c.ca,
 		CmcPolicies: c.policies,
 		ResultCb: func(result *ar.VerificationResult) {
-			if c.Publish != "" && (c.Attest == "mutual" || c.Attest == "client") {
+			if c.Publish != "" && (c.attest == atls.Attest_Mutual || c.attest == atls.Attest_Client) {
 				// Publish the attestation result if publishing address was specified
 				// and result is not empty
 				go publishResult(c.Publish, result)

--- a/testtool/tls.go
+++ b/testtool/tls.go
@@ -42,12 +42,12 @@ func dialInternalAddr(c *config, api atls.CmcApiSelect, addr string, tlsConf *tl
 		atls.WithCmcPolicies(c.policies),
 		atls.WithCmcApi(api),
 		atls.WithMtls(c.Mtls),
-		atls.WithAttest(c.Attest),
+		atls.WithAttest(c.attest),
 		atls.WithCmcNetwork(c.Network),
 		atls.WithResultCb(func(result *ar.VerificationResult) {
 			// Publish the attestation result asynchronously if publishing address was specified and
 			// and attestation was performed
-			if c.Publish != "" && (c.Attest == "mutual" || c.Attest == "server") {
+			if c.Publish != "" && (c.attest == atls.Attest_Mutual || c.attest == atls.Attest_Server) {
 				wg := new(sync.WaitGroup)
 				wg.Add(1)
 				defer wg.Wait()
@@ -116,8 +116,6 @@ func dialInternal(c *config, api atls.CmcApiSelect, cmc *cmc.Cmc) {
 			Renegotiation: tls.RenegotiateNever,
 		}
 	}
-
-	atls.WithAttest(c.Attest)
 
 	internal.PrintTlsConfig(tlsConf, c.ca)
 
@@ -197,10 +195,10 @@ func listenInternal(c *config, api atls.CmcApiSelect, cmc *cmc.Cmc) {
 		atls.WithCmcPolicies(c.policies),
 		atls.WithCmcApi(api),
 		atls.WithMtls(c.Mtls),
-		atls.WithAttest(c.Attest),
+		atls.WithAttest(c.attest),
 		atls.WithCmcNetwork(c.Network),
 		atls.WithResultCb(func(result *ar.VerificationResult) {
-			if c.Publish != "" && (c.Attest == "mutual" || c.Attest == "client") {
+			if c.Publish != "" && (c.attest == atls.Attest_Mutual || c.attest == atls.Attest_Client) {
 				// Publish the attestation result if publishing address was specified
 				// and result is not empty
 				go publishResult(c.Publish, result)
@@ -214,8 +212,9 @@ func listenInternal(c *config, api atls.CmcApiSelect, cmc *cmc.Cmc) {
 	}
 	defer ln.Close()
 
+	log.Infof("Serving under %v", addr)
+
 	for {
-		log.Infof("serving under %v", addr)
 		// Accept connection and perform remote attestation
 		conn, err := ln.Accept()
 		if err != nil {


### PR DESCRIPTION
Use simple cbor-encoded protocol for clean connection establishment and shutdown and errors and to prepare for caching mechanism to reduce data to be sent.