### PR TITLE
treewide: Refactoring: generic reference values.

### DIFF
--- a/attestationreport/attestationreport.go
+++ b/attestationreport/attestationreport.go
@@ -28,7 +28,7 @@ import (
 
 // The attestation report and verification result version
 const (
-	arVersion = "1.0.0"
+	arVersion = "1.1.0"
 )
 
 func GetVersion() string {
@@ -135,15 +135,18 @@ type CertConfig struct {
 }
 
 // ReferenceValue represents the attestation report
-// element of types 'SNP Reference Value', 'TPM Reference Value', 'TDX Reference Value', 'SGX Reference Value'
-// and 'SW Reference Value'
+// element of types 'SNP Reference Value', 'TPM Reference Value', 'TDX Reference Value',
+// 'SGX Reference Value' and 'SW Reference Value'. The Index is the unique identifier for the
+// reference value: This is the number of the PCR in case of TPM reference values,
+// the MR index according to UEFI Spec 2.10 Section 38.4.1 in case of TDX reference values, and
+// simply a monotonic counter for other reference values.
 type ReferenceValue struct {
 	Type        string      `json:"type" cbor:"0,keyasint"`
-	Sha256      HexByte     `json:"sha256,omitempty" cbor:"1,keyasint,omitempty"`
-	Sha384      HexByte     `json:"sha384,omitempty" cbor:"2,keyasint,omitempty"`
-	Name        string      `json:"name,omitempty" cbor:"3,keyasint,omitempty"`
-	Optional    bool        `json:"optional,omitempty" cbor:"4,keyasint,omitempty"`
-	Pcr         *int        `json:"pcr,omitempty" cbor:"5,keyasint,omitempty"`
+	SubType     string      `json:"subtype" cbor:"1,keyasint,omitempty"`
+	Index       int         `json:"index" cbor:"2,keyasint"`
+	Sha256      HexByte     `json:"sha256,omitempty" cbor:"3,keyasint,omitempty"`
+	Sha384      HexByte     `json:"sha384,omitempty" cbor:"4,keyasint,omitempty"`
+	Optional    bool        `json:"optional,omitempty" cbor:"5,keyasint,omitempty"`
 	Snp         *SnpDetails `json:"snp,omitempty" cbor:"6,keyasint,omitempty"`
 	Tdx         *TDXDetails `json:"tdx,omitempty" cbor:"7,keyasint,omitempty"`
 	Sgx         *SGXDetails `json:"sgx,omitempty" cbor:"8,keyasint,omitempty"`
@@ -160,17 +163,18 @@ type Validity struct {
 }
 
 // Artifact represents the digests of a measurement.
-// If the type is 'PCR Summary', 'Events' contains the final PCR value of PCR 'Pcr'.
+// If the type is 'PCR Summary', 'Events' contains the final PCR value of PCR 'Pcr' and 'Index'
+// contains the number of the PCR.
 // If the type is 'PCR Eventlog', 'Events' contains a list of the extends that lead to the final
-// PCR value. The list is retrieved by the prover, e.g., from the TPM binary bios measurements
-// list or the IMA runtime measurements list.
+// PCR value and 'Index' contains the number of the PCR. The list is retrieved by the prover, e.g.,
+// from the TPM binary bios measurements list or the IMA runtime measurements list.
 // If the type is 'SW Eventlog', 'Events' contains a list of digests that have been recorded as
 // SW measurements
 // If the type is 'TDX Collateral', 'Events' contains the TDX collateral, which includes the
 // TDX TCB info, the quoting enclave identity and the certicate revocation lists.
 type Artifact struct {
 	Type   string         `json:"type" cbor:"0,keyasint"`
-	Pcr    *int           `json:"pcr,omitempty" cbor:"1,keyasint,omitempty"`
+	Index  int            `json:"index" cbor:"1,keyasint"`
 	Events []MeasureEvent `json:"events,omitempty" cbor:"3,keyasint,omitempty"`
 }
 

--- a/tools/measure-bundle/main.go
+++ b/tools/measure-bundle/main.go
@@ -74,18 +74,18 @@ func main() {
 	pcr := 11
 	configRef := ar.ReferenceValue{
 		Type:     "TPM Reference Value",
-		Name:     "OCI Runtime Config",
+		SubType:  "OCI Runtime Config",
 		Sha256:   configHash,
-		Pcr:      &pcr,
+		Index:    pcr,
 		Optional: true,
 	}
 	refs = append(refs, configRef)
 
 	rootfsRef := ar.ReferenceValue{
 		Type:     "TPM Reference Value",
-		Name:     "OCI Runtime Rootfs",
+		SubType:  "OCI Runtime Rootfs",
 		Sha256:   rootfsHash,
-		Pcr:      &pcr,
+		Index:    pcr,
 		Optional: true,
 	}
 	refs = append(refs, rootfsRef)

--- a/tpmdriver/bioseventlog.go
+++ b/tpmdriver/bioseventlog.go
@@ -232,7 +232,6 @@ func parseBiosMeasurements(data []byte) ([]ar.ReferenceValue, error) {
 		if !(len(sha384Digest) == SHA384_DIGEST_LEN || len(sha256Digest) == SHA256_DIGEST_LEN) {
 			return nil, errors.New("no SHA256 or SHA384 in TCG event entry")
 		}
-		pcrP := int(pcrIndex)
 
 		//skip event
 		if eventName == eventtypeToString(EV_NO_ACTION) {
@@ -240,8 +239,14 @@ func parseBiosMeasurements(data []byte) ([]ar.ReferenceValue, error) {
 		}
 
 		//add to extends
-		extends = append(extends, ar.ReferenceValue{Type: EVENT_TYPE, Sha256: sha256Digest, Sha384: sha384Digest, Name: eventName,
-			Pcr: &pcrP, Snp: nil, EventData: extendedeventData})
+		extends = append(extends, ar.ReferenceValue{
+			Type:      EVENT_TYPE,
+			Index:     int(pcrIndex),
+			Sha256:    sha256Digest,
+			Sha384:    sha384Digest,
+			SubType:   eventName,
+			EventData: extendedeventData,
+		})
 
 	}
 
@@ -279,7 +284,12 @@ func generateLocalityEntry(pcrIndex int, eventType uint32, eventData []uint8) (a
 	digest := make([]byte, 32)
 	digest[31] = locality
 
-	entry := ar.ReferenceValue{Type: "INITVAL", Sha256: digest, Sha384: nil, Name: "TPM_PCR_INIT_VALUE", Pcr: &pcrIndex, Snp: nil, Description: "", EventData: nil}
+	entry := ar.ReferenceValue{
+		Type:    "INITVAL",
+		Sha256:  digest,
+		SubType: "TPM_PCR_INIT_VALUE",
+		Index:   pcrIndex,
+	}
 
 	//generate the Locality
 	return entry, skipEvent, nil

--- a/verifier/iat.go
+++ b/verifier/iat.go
@@ -131,20 +131,20 @@ func verifyIasMeasurements(iasM ar.Measurement, nonce []byte, cas []*x509.Certif
 	log.Debug("Verifying measurements")
 
 	// Verify that every reference value has a corresponding measurement
-	for _, ver := range referenceValues {
-		log.Tracef("Found reference value %v: %v", ver.Name, hex.EncodeToString(ver.Sha256))
-		if ver.Type != "IAS Reference Value" {
-			log.Tracef("IAS Reference Value invalid type %v", ver.Type)
+	for _, ref := range referenceValues {
+		log.Tracef("Found reference value %v: %v", ref.SubType, hex.EncodeToString(ref.Sha256))
+		if ref.Type != "IAS Reference Value" {
+			log.Tracef("IAS Reference Value invalid type %v", ref.Type)
 			result.Summary.SetErr(ar.RefValType)
 			return result, false
 		}
 		found := false
 		for _, swc := range iat.SwComponents {
-			if bytes.Equal(ver.Sha256, swc.MeasurementValue) {
+			if bytes.Equal(ref.Sha256, swc.MeasurementValue) {
 				result.Artifacts = append(result.Artifacts,
 					ar.DigestResult{
-						Name:     ver.Name,
-						Digest:   hex.EncodeToString(ver.Sha256),
+						SubType:  ref.SubType,
+						Digest:   hex.EncodeToString(ref.Sha256),
 						Success:  true,
 						Launched: true,
 					})
@@ -155,8 +155,8 @@ func verifyIasMeasurements(iasM ar.Measurement, nonce []byte, cas []*x509.Certif
 			ok = false
 			result.Artifacts = append(result.Artifacts,
 				ar.DigestResult{
-					Name:     ver.Name,
-					Digest:   hex.EncodeToString(ver.Sha256),
+					SubType:  ref.SubType,
+					Digest:   hex.EncodeToString(ref.Sha256),
 					Success:  false,
 					Launched: false,
 					Type:     "Reference Value",
@@ -172,7 +172,7 @@ func verifyIasMeasurements(iasM ar.Measurement, nonce []byte, cas []*x509.Certif
 		for _, ver := range referenceValues {
 			if bytes.Equal(ver.Sha256, swc.MeasurementValue) {
 				result.Artifacts = append(result.Artifacts, ar.DigestResult{
-					Name:     ver.Name,
+					SubType:  ver.SubType,
 					Digest:   hex.EncodeToString(swc.MeasurementValue),
 					Success:  true,
 					Launched: true,
@@ -183,7 +183,7 @@ func verifyIasMeasurements(iasM ar.Measurement, nonce []byte, cas []*x509.Certif
 		if !found {
 			ok = false
 			result.Artifacts = append(result.Artifacts, ar.DigestResult{
-				Name:     swc.MeasurementDescription,
+				SubType:  swc.MeasurementDescription,
 				Digest:   hex.EncodeToString(swc.MeasurementValue),
 				Success:  false,
 				Launched: true,

--- a/verifier/iat_test.go
+++ b/verifier/iat_test.go
@@ -180,20 +180,20 @@ var (
 	validNspeMeasurement, _ = hex.DecodeString("73deb833155c9c317d838b5368b6a63bd38706fa874e874c1b5affe4571b348b")
 
 	validSpeReferenceValue = ar.ReferenceValue{
-		Type:   "IAS Reference Value",
-		Name:   "SPE Measurement",
-		Sha256: validSpeMeasurement,
+		Type:    "IAS Reference Value",
+		SubType: "SPE Measurement",
+		Sha256:  validSpeMeasurement,
 	}
 
 	invalidSpeReferenceValue = ar.ReferenceValue{
-		Type:   "IAS Reference Value",
-		Name:   "SPE Measurement",
-		Sha256: invalidSpeMeasurement,
+		Type:    "IAS Reference Value",
+		SubType: "SPE Measurement",
+		Sha256:  invalidSpeMeasurement,
 	}
 
 	validNspeReferenceValue = ar.ReferenceValue{
-		Type:   "IAS Reference Value",
-		Name:   "NSPE Measurement",
-		Sha256: validNspeMeasurement,
+		Type:    "IAS Reference Value",
+		SubType: "NSPE Measurement",
+		Sha256:  validNspeMeasurement,
 	}
 )

--- a/verifier/sgx.go
+++ b/verifier/sgx.go
@@ -281,66 +281,66 @@ func VerifySgxQuoteBody(body *EnclaveReportBody, tcbInfo *TcbInfo,
 	if !bytes.Equal(body.MRENCLAVE[:], []byte(sgxReferenceValue.Sha256)) {
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     sgxReferenceValue.Name,
+				Type:     "Reference Value",
+				SubType:  sgxReferenceValue.SubType,
 				Digest:   hex.EncodeToString(sgxReferenceValue.Sha256[:]),
 				Success:  false,
 				Launched: false,
-				Type:     "Reference Value",
 			})
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     sgxReferenceValue.Name,
+				Type:     "Measurement",
+				SubType:  sgxReferenceValue.SubType,
 				Digest:   hex.EncodeToString(body.MRENCLAVE[:]),
 				Success:  false,
 				Launched: false,
-				Type:     "Measurement",
 			})
 		return fmt.Errorf("MRENCLAVE mismatch. Expected: %v, Got. %v", sgxReferenceValue.Sha256, body.MRENCLAVE)
 	} else {
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     sgxReferenceValue.Name,
+				Type:     "Measurement",
+				SubType:  sgxReferenceValue.SubType,
 				Digest:   hex.EncodeToString(body.MRENCLAVE[:]),
 				Success:  true,
 				Launched: true,
-				Type:     "Measurement",
 			})
 	}
 
 	result.Artifacts = append(result.Artifacts,
 		ar.DigestResult{
-			Name:     "MrSigner",
+			Type:     "Measurement",
+			SubType:  "MrSigner",
 			Digest:   hex.EncodeToString(body.MRSIGNER[:]),
 			Success:  strings.EqualFold(sgxReferenceValue.Sgx.MrSigner, hex.EncodeToString(body.MRSIGNER[:])),
 			Launched: true,
-			Type:     "Measurement",
 		},
 		ar.DigestResult{
-			Name:     "CpuSvn",
+			Type:     "Security Version",
+			SubType:  "CpuSvn",
 			Digest:   hex.EncodeToString(body.CPUSVN[:]),
 			Success:  bytes.Compare(sgxExtensions.Tcb.Value.CpuSvn.Value, body.CPUSVN[:]) <= 0,
 			Launched: true,
-			Type:     "Security Version",
 		},
 		ar.DigestResult{
-			Name:     "IsvProdId",
+			Type:     "Product ID",
+			SubType:  "IsvProdId",
 			Digest:   strconv.Itoa(int(body.ISVProdID)),
 			Success:  sgxReferenceValue.Sgx.IsvProdId == body.ISVProdID,
 			Launched: true,
-			Type:     "Product ID",
 		},
 		ar.DigestResult{
-			Name:     "IsvSvn",
+			Type:     "Security Version",
+			SubType:  "IsvSvn",
 			Digest:   strconv.Itoa(int(body.ISVSVN)),
 			Success:  sgxReferenceValue.Sgx.IsvSvn == body.ISVSVN,
 			Launched: true,
-			Type:     "Security Version",
 		},
 	)
 
 	for _, v := range result.Artifacts {
 		if !v.Success {
-			return fmt.Errorf("SGX Quote Body Verification failed. %v: (Got: %v)", v.Name, v.Digest)
+			return fmt.Errorf("SGX Quote Body Verification failed. %v: (Got: %v)", v.SubType, v.Digest)
 		}
 	}
 

--- a/verifier/snp.go
+++ b/verifier/snp.go
@@ -163,19 +163,19 @@ func verifySnpMeasurements(snpM ar.Measurement, nonce []byte, referenceValues []
 		log.Debug("Failed to verify SNP reference value")
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     snpReferenceValue.Name,
+				Type:     "Reference Value",
+				SubType:  snpReferenceValue.SubType,
 				Digest:   hex.EncodeToString(snpReferenceValue.Sha384),
 				Success:  false,
 				Launched: false,
-				Type:     "Reference Value",
 			})
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     snpReferenceValue.Name,
+				Type:     "Measurement",
+				SubType:  snpReferenceValue.SubType,
 				Digest:   hex.EncodeToString(s.Measurement[:]),
 				Success:  false,
 				Launched: true,
-				Type:     "Measurement",
 			})
 
 		ok = false
@@ -185,7 +185,7 @@ func verifySnpMeasurements(snpM ar.Measurement, nonce []byte, referenceValues []
 		// SNP Reference Value, we can set this here:
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     snpReferenceValue.Name,
+				SubType:  snpReferenceValue.SubType,
 				Digest:   hex.EncodeToString(s.Measurement[:]),
 				Success:  true,
 				Launched: true,

--- a/verifier/sw.go
+++ b/verifier/sw.go
@@ -106,7 +106,7 @@ func verifySwMeasurements(swMeasurement ar.Measurement, nonce []byte, cas []*x50
 				Type:       "Reference Value",
 				Success:    ref.Optional, // Only fail attestation if component is mandatory
 				Launched:   false,
-				Name:       ref.Name,
+				SubType:    ref.SubType,
 				Digest:     hex.EncodeToString(ref.Sha256),
 				CtrDetails: ar.GetCtrDetailsFromRefVal(&ref, s),
 			}
@@ -114,7 +114,7 @@ func verifySwMeasurements(swMeasurement ar.Measurement, nonce []byte, cas []*x50
 
 			// Only fail attestation if component is mandatory
 			if !ref.Optional {
-				log.Debugf("no SW Measurement found for mandatory SW reference value %v (hash: %v)", ref.Name, hex.EncodeToString(ref.Sha256))
+				log.Debugf("no SW Measurement found for mandatory SW reference value %v (hash: %v)", ref.SubType, hex.EncodeToString(ref.Sha256))
 				ok = false
 			}
 		}
@@ -150,14 +150,14 @@ func verifySwMeasurements(swMeasurement ar.Measurement, nonce []byte, cas []*x50
 					}
 
 					found = true
-					nameInfo := ref.Name
-					if event.EventName != "" && !strings.EqualFold(ref.Name, event.EventName) {
+					nameInfo := ref.SubType
+					if event.EventName != "" && !strings.EqualFold(ref.SubType, event.EventName) {
 						nameInfo += ": " + event.EventName
 					}
 					r := ar.DigestResult{
 						Success:    validateOk,
 						Launched:   true,
-						Name:       nameInfo,
+						SubType:    nameInfo,
 						Digest:     hex.EncodeToString(event.Sha256),
 						CtrDetails: event.CtrData,
 					}
@@ -174,7 +174,7 @@ func verifySwMeasurements(swMeasurement ar.Measurement, nonce []byte, cas []*x50
 					Type:       "Measurement",
 					Success:    false,
 					Launched:   true,
-					Name:       event.EventName,
+					SubType:    event.EventName,
 					Digest:     hex.EncodeToString(event.Sha256),
 					CtrDetails: event.CtrData,
 				}

--- a/verifier/sw_test.go
+++ b/verifier/sw_test.go
@@ -192,22 +192,22 @@ var (
 
 	validUbuntuRefVal = ar.ReferenceValue{
 		Type:     "SW Reference Value",
+		SubType:  "OCI Runtime Bundle Rootfs Digest: ubuntu:24.04",
 		Sha256:   dec("b3efcaa760118501b34effbb07d099d774ecf7ee0bddf6233c7e8bc958c16d1e"),
-		Name:     "OCI Runtime Bundle Rootfs Digest: ubuntu:24.04",
 		Optional: true,
 	}
 
 	validNginxRefVal = ar.ReferenceValue{
 		Type:     "SW Reference Value",
+		SubType:  "OCI Runtime Bundle Rootfs Digest: nginx:latest",
 		Sha256:   dec("627a04fe9d8c2b32aa07b6363fbd9ed0f9a533ff0ea9a25804f9cbdd7faba068"),
-		Name:     "OCI Runtime Bundle Rootfs Digest: nginx:latest",
 		Optional: true,
 	}
 
 	invalidSwRefVal = ar.ReferenceValue{
 		Type:     "SW Reference Value",
+		SubType:  "OCI Runtime Bundle Digest",
 		Sha256:   dec("ff5ed62e8fb85decea88ffee33274245d2924e2e961b3cc95be6e09a6ae5a25d"),
-		Name:     "OCI Runtime Bundle Digest",
 		Optional: true,
 	}
 

--- a/verifier/tdx.go
+++ b/verifier/tdx.go
@@ -356,25 +356,25 @@ func verifyTdxQuoteBody(body *TdxReportBody, tcbInfo *TcbInfo,
 	if !bytes.Equal(body.MrTd[:], []byte(tdxReferenceValue.Sha256)) {
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     tdxReferenceValue.Name,
+				Type:     "Reference Value",
+				SubType:  tdxReferenceValue.SubType,
 				Digest:   hex.EncodeToString(tdxReferenceValue.Sha256),
 				Success:  false,
 				Launched: false,
-				Type:     "Reference Value",
 			})
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     tdxReferenceValue.Name,
+				Type:     "Measurement",
+				SubType:  tdxReferenceValue.SubType,
 				Digest:   hex.EncodeToString(body.MrTd[:]),
 				Success:  false,
 				Launched: true,
-				Type:     "Measurement",
 			})
 		return fmt.Errorf("MrTd mismatch. Expected: %v, Got. %v", tdxReferenceValue.Sha256, body.MrTd)
 	} else {
 		result.Artifacts = append(result.Artifacts,
 			ar.DigestResult{
-				Name:     tdxReferenceValue.Name,
+				SubType:  tdxReferenceValue.SubType,
 				Digest:   hex.EncodeToString(body.MrTd[:]),
 				Success:  true,
 				Launched: true,
@@ -383,63 +383,63 @@ func verifyTdxQuoteBody(body *TdxReportBody, tcbInfo *TcbInfo,
 
 	result.Artifacts = append(result.Artifacts,
 		ar.DigestResult{
-			Name:     "MrSignerSeam",
+			SubType:  "MrSignerSeam",
 			Digest:   hex.EncodeToString(body.MrSignerSeam[:]),
 			Success:  bytes.Equal(tcbInfo.TcbInfo.TdxModule.Mrsigner[:], body.MrSignerSeam[:]),
 			Launched: true,
 			Type:     "Measurement",
 		},
 		ar.DigestResult{
-			Name:     "MrSeam",
+			SubType:  "MrSeam",
 			Digest:   hex.EncodeToString(body.MrSeam[:]),
 			Success:  bytes.Equal(body.MrSeam[:], tdxReferenceValue.Tdx.TdMeas.MrSeam),
 			Launched: true,
 			Type:     "Measurement",
 		},
 		ar.DigestResult{
-			Name:     "RtMr0",
+			SubType:  "RtMr0",
 			Digest:   hex.EncodeToString(body.RtMr0[:]),
 			Success:  recalculateRtMr(body.RtMr0[:], tdxReferenceValue.Tdx.TdMeas.RtMr0),
 			Launched: true,
 			Type:     "Firmware Measurement",
 		},
 		ar.DigestResult{
-			Name:     "RtMr1",
+			SubType:  "RtMr1",
 			Digest:   hex.EncodeToString(body.RtMr1[:]),
 			Success:  recalculateRtMr(body.RtMr1[:], tdxReferenceValue.Tdx.TdMeas.RtMr1),
 			Launched: true,
 			Type:     "BIOS Measurement",
 		},
 		ar.DigestResult{
-			Name:     "RtMr2",
+			SubType:  "RtMr2",
 			Digest:   hex.EncodeToString(body.RtMr2[:]),
 			Success:  recalculateRtMr(body.RtMr2[:], tdxReferenceValue.Tdx.TdMeas.RtMr2),
 			Launched: true,
 			Type:     "OS Measurement",
 		},
 		ar.DigestResult{
-			Name:     "RtMr3",
+			SubType:  "RtMr3",
 			Digest:   hex.EncodeToString(body.RtMr3[:]),
 			Success:  recalculateRtMr(body.RtMr3[:], tdxReferenceValue.Tdx.TdMeas.RtMr3),
 			Launched: true,
 			Type:     "Runtime Measurement",
 		},
 		ar.DigestResult{
-			Name:     "MrOwner",
+			SubType:  "MrOwner",
 			Digest:   hex.EncodeToString(body.MrOwner[:]),
 			Success:  bytes.Equal(tdxReferenceValue.Tdx.TdId.MrOwner[:], body.MrOwner[:]),
 			Launched: true,
 			Type:     "Software-defined ID",
 		},
 		ar.DigestResult{
-			Name:     "MrOwnerConfig",
+			SubType:  "MrOwnerConfig",
 			Digest:   hex.EncodeToString(body.MrOwnerConfig[:]),
 			Success:  bytes.Equal(tdxReferenceValue.Tdx.TdId.MrOwnerConfig[:], body.MrOwnerConfig[:]),
 			Launched: true,
 			Type:     "Software-defined ID",
 		},
 		ar.DigestResult{
-			Name:     "MrConfigId",
+			SubType:  "MrConfigId",
 			Digest:   hex.EncodeToString(body.MrConfigId[:]),
 			Success:  bytes.Equal(tdxReferenceValue.Tdx.TdId.MrConfigId[:], body.MrConfigId[:]),
 			Launched: true,
@@ -508,9 +508,9 @@ func verifyTdxQuoteBody(body *TdxReportBody, tcbInfo *TcbInfo,
 			result.TdxResult.XfamCheck.Claimed, result.TdxResult.XfamCheck.Measured)
 	}
 
-	for _, v := range result.Artifacts {
-		if !v.Success {
-			return fmt.Errorf("TDX Quote Body Verification failed. %v: (Got: %v)", v.Name, v.Digest)
+	for _, a := range result.Artifacts {
+		if !a.Success {
+			return fmt.Errorf("TDX Quote Body Verification failed. %v: (Got: %v)", a.SubType, a.Digest)
 		}
 	}
 

--- a/verifier/tpm_test.go
+++ b/verifier/tpm_test.go
@@ -229,8 +229,6 @@ func dec(s string) []byte {
 	return b
 }
 
-func ptr[T any](v T) *T { return &v }
-
 func conv(d []byte) *x509.Certificate {
 	input := d
 	block, _ := pem.Decode(d)
@@ -253,15 +251,15 @@ var (
 
 	validSummaryHashChain = []ar.Artifact{
 		{
-			Type: "PCR Summary",
-			Pcr:  ptr(1),
+			Type:  "PCR Summary",
+			Index: 1,
 			Events: []ar.MeasureEvent{
 				{Sha256: dec("5f96aec0a6b390185495c35bc76dceb9fa6addb4e59b6fc1b3e1992eeb08a5c6")},
 			},
 		},
 		{
-			Type: "PCR Summary",
-			Pcr:  ptr(4),
+			Type:  "PCR Summary",
+			Index: 4,
 			Events: []ar.MeasureEvent{
 				{Sha256: dec("d3f67dbed9bce9d391a3567edad08971339e4dbabadd5b7eaf082860296e5e72")},
 			},
@@ -270,15 +268,15 @@ var (
 
 	invalidSummaryHashChain = []ar.Artifact{
 		{
-			Type: "PCR Summary",
-			Pcr:  ptr(1),
+			Type:  "PCR Summary",
+			Index: 1,
 			Events: []ar.MeasureEvent{
 				{Sha256: dec("2a814d03d22568e2d669595dd8be199fd7b3df2acb8caae38e24e92605e15c80")},
 			},
 		},
 		{
-			Type: "PCR Summary",
-			Pcr:  ptr(4),
+			Type:  "PCR Summary",
+			Index: 4,
 			Events: []ar.MeasureEvent{
 				{Sha256: dec("1fe8f1a49cf178748a6f6167473bca3cf882ff70b4b4e458e2421c871c9c5bb9")},
 			},
@@ -287,8 +285,8 @@ var (
 
 	validHashChain = []ar.Artifact{
 		{
-			Type: "PCR Eventlog",
-			Pcr:  ptr(1),
+			Type:  "PCR Eventlog",
+			Index: 1,
 			Events: []ar.MeasureEvent{
 				{Sha256: dec("ef5631c7bbb8d98ad220e211933fcde16aac6154cf229fea3c728fb0f2c27e39")},
 				{Sha256: dec("131462b45df65ac00834c7e73356c246037456959674acd24b08357690a03845")},
@@ -302,8 +300,8 @@ var (
 			},
 		},
 		{
-			Type: "PCR Eventlog",
-			Pcr:  ptr(4),
+			Type:  "PCR Eventlog",
+			Index: 4,
 			Events: []ar.MeasureEvent{
 				{Sha256: dec("3d6772b4f84ed47595d72a2c4c5ffd15f5bb72c7507fe26f2aaee2c69d5633ba")},
 				{Sha256: dec("df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119")},
@@ -316,8 +314,8 @@ var (
 
 	invalidHashChain = []ar.Artifact{
 		{
-			Type: "PCR Eventlog",
-			Pcr:  ptr(1),
+			Type:  "PCR Eventlog",
+			Index: 1,
 			Events: []ar.MeasureEvent{
 				{Sha256: dec("ff5631c7bbb8d98ad220e211933fcde16aac6154cf229fea3c728fb0f2c27e39")},
 				{Sha256: dec("131462b45df65ac00834c7e73356c246037456959674acd24b08357690a03845")},
@@ -331,8 +329,8 @@ var (
 			},
 		},
 		{
-			Type: "PCR Eventlog",
-			Pcr:  ptr(4),
+			Type:  "PCR Eventlog",
+			Index: 4,
 			Events: []ar.MeasureEvent{
 				{Sha256: dec("3d6772b4f84ed47595d72a2c4c5ffd15f5bb72c7507fe26f2aaee2c69d5633ba")},
 				{Sha256: dec("df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119")},
@@ -360,97 +358,97 @@ var (
 
 	validReferenceValues = []ar.ReferenceValue{
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("ef5631c7bbb8d98ad220e211933fcde16aac6154cf229fea3c728fb0f2c27e39"),
-			Name:   "EV_CPU_MICROCODE",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("ef5631c7bbb8d98ad220e211933fcde16aac6154cf229fea3c728fb0f2c27e39"),
+			SubType: "EV_CPU_MICROCODE",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("131462b45df65ac00834c7e73356c246037456959674acd24b08357690a03845"),
-			Name:   "Unknown Event Type",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("131462b45df65ac00834c7e73356c246037456959674acd24b08357690a03845"),
+			SubType: "Unknown Event Type",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("8574d91b49f1c9a6ecc8b1e8565bd668f819ea8ed73c5f682948141587aecd3b"),
-			Name:   "EV_NONHOST_CONFIG",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("8574d91b49f1c9a6ecc8b1e8565bd668f819ea8ed73c5f682948141587aecd3b"),
+			SubType: "EV_NONHOST_CONFIG",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("afffbd73d1e4e658d5a1768f6fa11a6c38a1b5c94694015bc96418a7b5291b39"),
-			Name:   "EV_EFI_VARIABLE_BOOT",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("afffbd73d1e4e658d5a1768f6fa11a6c38a1b5c94694015bc96418a7b5291b39"),
+			SubType: "EV_EFI_VARIABLE_BOOT",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("6cf2851f19f1c3ec3070f20400892cb8e6ee712422efd77d655e2ebde4e00d69"),
-			Name:   "EV_EFI_VARIABLE_BOOT",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("6cf2851f19f1c3ec3070f20400892cb8e6ee712422efd77d655e2ebde4e00d69"),
+			SubType: "EV_EFI_VARIABLE_BOOT",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("faf98c184d571dd4e928f55bbf3b2a6e0fc60ba1fb393a9552f004f76ecf06a7"),
-			Name:   "EV_EFI_VARIABLE_BOOT",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("faf98c184d571dd4e928f55bbf3b2a6e0fc60ba1fb393a9552f004f76ecf06a7"),
+			SubType: "EV_EFI_VARIABLE_BOOT",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("b785d921b9516221dff929db343c124a832cceee1b508b36b7eb37dc50fc18d8"),
-			Name:   "EV_EFI_VARIABLE_BOOT",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("b785d921b9516221dff929db343c124a832cceee1b508b36b7eb37dc50fc18d8"),
+			SubType: "EV_EFI_VARIABLE_BOOT",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119"),
-			Name:   "EV_SEPARATOR",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119"),
+			SubType: "EV_SEPARATOR",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("b997bc194a4b65980eb0cb172bd5cc51a6460b79c047a92e8f4ff9f85d578bd4"),
-			Name:   "EV_PLATFORM_CONFIG_FLAGS",
-			Pcr:    &pcrs[1],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("b997bc194a4b65980eb0cb172bd5cc51a6460b79c047a92e8f4ff9f85d578bd4"),
+			SubType: "EV_PLATFORM_CONFIG_FLAGS",
+			Index:   pcrs[1],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("3d6772b4f84ed47595d72a2c4c5ffd15f5bb72c7507fe26f2aaee2c69d5633ba"),
-			Name:   "EV_EFI_ACTION",
-			Pcr:    &pcrs[4],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("3d6772b4f84ed47595d72a2c4c5ffd15f5bb72c7507fe26f2aaee2c69d5633ba"),
+			SubType: "EV_EFI_ACTION",
+			Index:   pcrs[4],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119"),
-			Name:   "EV_SEPARATOR",
-			Pcr:    &pcrs[4],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119"),
+			SubType: "EV_SEPARATOR",
+			Index:   pcrs[4],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("dbffd70a2c43fd2c1931f18b8f8c08c5181db15f996f747dfed34def52fad036"),
-			Name:   "EV_EFI_BOOT_SERVICES_APPLICATION",
-			Pcr:    &pcrs[4],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("dbffd70a2c43fd2c1931f18b8f8c08c5181db15f996f747dfed34def52fad036"),
+			SubType: "EV_EFI_BOOT_SERVICES_APPLICATION",
+			Index:   pcrs[4],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("acc00aad4b0413a8b349b4493f95830da6a7a44bd6fc1579f6f53c339c26cb05"),
-			Name:   "EV_EFI_BOOT_SERVICES_APPLICATION",
-			Pcr:    &pcrs[4],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("acc00aad4b0413a8b349b4493f95830da6a7a44bd6fc1579f6f53c339c26cb05"),
+			SubType: "EV_EFI_BOOT_SERVICES_APPLICATION",
+			Index:   pcrs[4],
 		},
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("3ba11d87f4450f0b92bd53676d88a3622220a7d53f0338bf387badc31cf3c025"),
-			Name:   "EV_EFI_BOOT_SERVICES_APPLICATION",
-			Pcr:    &pcrs[4],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("3ba11d87f4450f0b92bd53676d88a3622220a7d53f0338bf387badc31cf3c025"),
+			SubType: "EV_EFI_BOOT_SERVICES_APPLICATION",
+			Index:   pcrs[4],
 		},
 	}
 
 	invalidReferenceValues = []ar.ReferenceValue{
 		{
-			Type:   "TPM Reference Value",
-			Sha256: dec("1310b2b63dc1222516e5c12cedc1cc48e338f85430849b5a5b5256467e2cd0f0"),
-			Name:   "SINIT ACM Digest",
-			Pcr:    &pcrs[4],
+			Type:    "TPM Reference Value",
+			Sha256:  dec("1310b2b63dc1222516e5c12cedc1cc48e338f85430849b5a5b5256467e2cd0f0"),
+			SubType: "SINIT ACM Digest",
+			Index:   pcrs[4],
 		},
 	}
 
@@ -461,99 +459,99 @@ var (
 	validArtifacts = []ar.DigestResult{
 		{
 			Digest:   "ef5631c7bbb8d98ad220e211933fcde16aac6154cf229fea3c728fb0f2c27e39",
-			Name:     "EV_CPU_MICROCODE",
-			Pcr:      ptr(1),
+			SubType:  "EV_CPU_MICROCODE",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "131462b45df65ac00834c7e73356c246037456959674acd24b08357690a03845",
-			Name:     "Unknown Event Type",
-			Pcr:      ptr(1),
+			SubType:  "Unknown Event Type",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "8574d91b49f1c9a6ecc8b1e8565bd668f819ea8ed73c5f682948141587aecd3b",
-			Name:     "EV_NONHOST_CONFIG",
-			Pcr:      ptr(1),
+			SubType:  "EV_NONHOST_CONFIG",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "afffbd73d1e4e658d5a1768f6fa11a6c38a1b5c94694015bc96418a7b5291b39",
-			Name:     "EV_EFI_VARIABLE_BOOT",
-			Pcr:      ptr(1),
+			SubType:  "EV_EFI_VARIABLE_BOOT",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "6cf2851f19f1c3ec3070f20400892cb8e6ee712422efd77d655e2ebde4e00d69",
-			Name:     "EV_EFI_VARIABLE_BOOT",
-			Pcr:      ptr(1),
+			SubType:  "EV_EFI_VARIABLE_BOOT",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "faf98c184d571dd4e928f55bbf3b2a6e0fc60ba1fb393a9552f004f76ecf06a7",
-			Name:     "EV_EFI_VARIABLE_BOOT",
-			Pcr:      ptr(1),
+			SubType:  "EV_EFI_VARIABLE_BOOT",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "b785d921b9516221dff929db343c124a832cceee1b508b36b7eb37dc50fc18d8",
-			Name:     "EV_EFI_VARIABLE_BOOT",
-			Pcr:      ptr(1),
+			SubType:  "EV_EFI_VARIABLE_BOOT",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119",
-			Name:     "EV_SEPARATOR",
-			Pcr:      ptr(1),
+			SubType:  "EV_SEPARATOR",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "b997bc194a4b65980eb0cb172bd5cc51a6460b79c047a92e8f4ff9f85d578bd4",
-			Name:     "EV_PLATFORM_CONFIG_FLAGS",
-			Pcr:      ptr(1),
+			SubType:  "EV_PLATFORM_CONFIG_FLAGS",
+			Index:    1,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "3d6772b4f84ed47595d72a2c4c5ffd15f5bb72c7507fe26f2aaee2c69d5633ba",
-			Name:     "EV_EFI_ACTION",
-			Pcr:      ptr(4),
+			SubType:  "EV_EFI_ACTION",
+			Index:    4,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "df3f619804a92fdb4057192dc43dd748ea778adc52bc498ce80524c014b81119",
-			Name:     "EV_SEPARATOR",
-			Pcr:      ptr(4),
+			SubType:  "EV_SEPARATOR",
+			Index:    4,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "dbffd70a2c43fd2c1931f18b8f8c08c5181db15f996f747dfed34def52fad036",
-			Name:     "EV_EFI_BOOT_SERVICES_APPLICATION",
-			Pcr:      ptr(4),
+			SubType:  "EV_EFI_BOOT_SERVICES_APPLICATION",
+			Index:    4,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "acc00aad4b0413a8b349b4493f95830da6a7a44bd6fc1579f6f53c339c26cb05",
-			Name:     "EV_EFI_BOOT_SERVICES_APPLICATION",
-			Pcr:      ptr(4),
+			SubType:  "EV_EFI_BOOT_SERVICES_APPLICATION",
+			Index:    4,
 			Success:  true,
 			Launched: true,
 		},
 		{
 			Digest:   "3ba11d87f4450f0b92bd53676d88a3622220a7d53f0338bf387badc31cf3c025",
-			Name:     "EV_EFI_BOOT_SERVICES_APPLICATION",
-			Pcr:      ptr(4),
+			SubType:  "EV_EFI_BOOT_SERVICES_APPLICATION",
+			Index:    4,
 			Success:  true,
 			Launched: true,
 		},

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -39,11 +39,11 @@ import (
 // variables for Test_collectReferenceValues
 var (
 	refs = []ar.ReferenceValue{
-		{Type: "TPM Reference Value", Name: "TPM1"},
-		{Type: "TPM Reference Value", Name: "TPM2"},
-		{Type: "SNP Reference Value", Name: "SNP1"},
-		{Type: "SW Reference Value", Name: "SW1"},
-		{Type: "SW Reference Value", Name: "SW2"},
+		{Type: "TPM Reference Value", SubType: "TPM1"},
+		{Type: "TPM Reference Value", SubType: "TPM2"},
+		{Type: "SNP Reference Value", SubType: "SNP1"},
+		{Type: "SW Reference Value", SubType: "SW1"},
+		{Type: "SW Reference Value", SubType: "SW2"},
 	}
 
 	refMap = map[string][]ar.ReferenceValue{
@@ -469,12 +469,12 @@ func Test_collectReferenceValues(t *testing.T) {
 				for _, wantedrefval := range wantedrefvals {
 					found := false
 					for _, gotrefval := range got[wantedkey] {
-						if gotrefval.Name == wantedrefval.Name {
+						if gotrefval.SubType == wantedrefval.SubType {
 							found = true
 						}
 					}
 					if !found {
-						t.Errorf("collectReferenceValues() failed to find %v", wantedrefval.Name)
+						t.Errorf("collectReferenceValues() failed to find %v", wantedrefval.SubType)
 					}
 				}
 			}
@@ -677,7 +677,7 @@ func TestVerify(t *testing.T) {
 
 			report := ar.AttestationReport{
 				Type:    "Attestation Report",
-				Version: "1.0.0",
+				Version: "1.1.0",
 				Metadata: []ar.MetadataDigest{
 					rtmManifestDigest, osManifestDigest, appManifestDigest, deviceDescriptionDigest,
 				},


### PR DESCRIPTION
Replace 'PCR' fields with generic index fields to prepare support for Intel TDX reference values with a PCR to TDX MR mapping according to the UEFI specification.